### PR TITLE
encrypted-len-check

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var aes256 = {
     if (typeof key !== 'string' || !key) {
       throw new TypeError('Provided "key" must be a non-empty string');
     }
-    if (typeof encrypted !== 'string' || !encrypted || encrypted.length < 17) {
+    if (typeof encrypted !== 'string' || !encrypted ) {
       throw new TypeError('Provided "encrypted" must be a non-empty string');
     }
 
@@ -72,6 +72,9 @@ var aes256 = {
     sha256.update(key);
 
     var input = new Buffer(encrypted, 'base64');
+    if (input.length < 17) {
+      throw new TypeError('Provided "encrypted" must be a non-empty string');
+    }
 
     // Initialization Vector
     var iv = input.slice(0, 16);


### PR DESCRIPTION
The length check for encrypted string input to decrypt function needs to be done after decoding from base64, as base64 changes the length.

Without this update, a 16 byte input to the decrypt function (encrypted) will always return an empty string for plaintext, no matter what the key.