### PR TITLE
Add ability to encrypt and decrypt from Buffers directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,15 @@ var aes256 = require('aes256');
 
 var key = 'my passphrase';
 var plaintext = 'my plaintext message';
+var buffer = new Buffer(plaintext);
 
-var encrypted = aes256.encrypt(key, plaintext);
-var decrypted = aes256.decrypt(key, encrypted);
+var encryptedPlainText = aes256.encrypt(key, plaintext);
+var decryptedPlainText = aes256.decrypt(key, encryptedPlainText);
+// plaintext === decryptedPlainText
 
-// plaintext === decrypted
+var encryptedBuffer = aes256.encrypt(key, buffer);
+var decryptedBuffer = aes256.decrypt(key, encryptedBuffer);
+// plaintext === decryptedBuffer.toString('utf8)
 ```
 
 
@@ -40,13 +44,17 @@ var aes256 = require('aes256');
 
 var key = 'my passphrase';
 var plaintext = 'my plaintext message';
+var buffer = new Buffer(plaintext);
 
 var cipher = aes256.createCipher(key);
 
-var encrypted = cipher.encrypt(plaintext);
-var decrypted = cipher.decrypt(encrypted);
+var encryptedPlainText = cipher.encrypt(plaintext);
+var decryptedPlainText = cipher.decrypt(encryptedPlainText);
+// plaintext === decryptedPlainText
 
-// plaintext === decrypted
+var encryptedBuffer = cipher.encrypt(buffer);
+var decryptedBuffer = cipher.decrypt(encryptedBuffer);
+// plaintext === decryptedBuffer.toString('utf8)
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,10 @@ var aes256 = {
     if (typeof key !== 'string' || !key) {
       throw new TypeError('Provided "key" must be a non-empty string');
     }
-    if (!(typeof input === 'string' || Buffer.isBuffer(input)) || !input) {
+
+    var isString = typeof input === 'string';
+    var isBuffer = Buffer.isBuffer(input);
+    if (!(isString || isBuffer) || (isString && !input) || (isBuffer && !Buffer.byteLength(input))) {
       throw new TypeError('Provided "input" must be a non-empty string or buffer');
     }
 
@@ -45,8 +48,6 @@ var aes256 = {
     // Initialization Vector
     var iv = crypto.randomBytes(16);
     var cipher = crypto.createCipheriv(CIPHER_ALGORITHM, sha256.digest(), iv);
-
-    var isString = typeof input === 'string';
 
     var buffer = input;
     if (isString) {
@@ -75,22 +76,27 @@ var aes256 = {
     if (typeof key !== 'string' || !key) {
       throw new TypeError('Provided "key" must be a non-empty string');
     }
-    if (!(typeof encrypted === 'string' || Buffer.isBuffer(encrypted)) || !encrypted) {
+
+    var isString = typeof encrypted === 'string';
+    var isBuffer = Buffer.isBuffer(encrypted);
+    if (!(isString || isBuffer) || (isString && !encrypted) || (isBuffer && !Buffer.byteLength(encrypted))) {
       throw new TypeError('Provided "encrypted" must be a non-empty string or buffer');
     }
 
     var sha256 = crypto.createHash('sha256');
     sha256.update(key);
 
-    var isString = typeof encrypted === 'string';
-
     var input = encrypted;
     if (isString) {
       input = new Buffer(encrypted, 'base64');
-    }
 
-    if (input.length < 17) {
-      throw new TypeError('Provided "encrypted" must decrypt to a non-empty string or buffer');
+      if (input.length < 17) {
+        throw new TypeError('Provided "encrypted" must decrypt to a non-empty string or buffer');
+      }
+    } else {
+      if (Buffer.byteLength(encrypted) < 17) {
+        throw new TypeError('Provided "encrypted" must decrypt to a non-empty string or buffer');
+      }
     }
 
     // Initialization Vector

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -64,27 +64,27 @@ describe('aes256', function() {
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
-    it('should throw an Error if a null `plaintext` is provided', function() {
+    it('should throw an Error if a null `input` is provided', function() {
       var fn = function() {
         return api.encrypt(validKey, null);
       };
-      var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
-    it('should throw an Error if a non-string `plaintext` is provided', function() {
+    it('should throw an Error if a non-string and non-buffer `input` is provided', function() {
       var fn = function() {
         return api.encrypt(validKey, {});
       };
-      var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
-    it('should throw an Error if a empty string `plaintext` is provided', function() {
+    it('should throw an Error if a empty string `input` is provided', function() {
       var fn = function() {
         return api.encrypt(validKey, '');
       };
-      var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
@@ -162,15 +162,15 @@ describe('aes256', function() {
       var fn = function() {
         return api.decrypt('my magical passphrase', null);
       };
-      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
-    it('should throw an Error if a non-string `encrypted` is provided', function() {
+    it('should throw an Error if a non-string and non-buffer `encrypted` is provided', function() {
       var fn = function() {
         return api.decrypt('my magical passphrase', {});
       };
-      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
@@ -178,7 +178,7 @@ describe('aes256', function() {
       var fn = function() {
         return api.decrypt('my magical passphrase', '');
       };
-      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
@@ -187,7 +187,7 @@ describe('aes256', function() {
         // string length >= 17, Buffer length < 17
         return api.decrypt('my magical passphrase', 'abcdef1234567890abcdef');  // length < 17
       };
-      var expectedErrMsgRegExp = /^Provided "encrypted" must decrypt to a non-empty string$/;
+      var expectedErrMsgRegExp = /^Provided "encrypted" must decrypt to a non-empty string or buffer$/;
       expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
     });
 
@@ -319,27 +319,27 @@ describe('aes256', function() {
           expect(encrypted1).to.not.equal(encrypted2);
         });
 
-        it('should throw an Error if a null `plaintext` is provided', function() {
+        it('should throw an Error if a null `input` is provided', function() {
           var fn = function() {
             return validCipher.encrypt(null);
           };
-          var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
-        it('should throw an Error if a non-string `plaintext` is provided', function() {
+        it('should throw an Error if a non-string and non-buffer `input` is provided', function() {
           var fn = function() {
             return validCipher.encrypt({});
           };
-          var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
-        it('should throw an Error if a empty string `plaintext` is provided', function() {
+        it('should throw an Error if a empty string `input` is provided', function() {
           var fn = function() {
             return validCipher.encrypt('');
           };
-          var expectedErrMsgRegExp = /^Provided "plaintext" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "input" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
@@ -410,15 +410,15 @@ describe('aes256', function() {
           var fn = function() {
             return validCipher.decrypt(null);
           };
-          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
-        it('should throw an Error if a non-string `encrypted` is provided', function() {
+        it('should throw an Error if a non-string and non-buffer `encrypted` is provided', function() {
           var fn = function() {
             return validCipher.decrypt({});
           };
-          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
@@ -426,7 +426,7 @@ describe('aes256', function() {
           var fn = function() {
             return validCipher.decrypt('');
           };
-          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "encrypted" must be a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 
@@ -435,7 +435,7 @@ describe('aes256', function() {
             // string length >= 17, Buffer length < 17
             return validCipher.decrypt('abcdef1234567890abcdef');
           };
-          var expectedErrMsgRegExp = /^Provided "encrypted" must decrypt to a non-empty string$/;
+          var expectedErrMsgRegExp = /^Provided "encrypted" must decrypt to a non-empty string or buffer$/;
           expect(fn).to.throw(TypeError, expectedErrMsgRegExp);
         });
 


### PR DESCRIPTION
Fixes issue #7.

The encrypt/decrypt functions both can accept a Buffer directly. If passed a Buffer as input, the output will also be a Buffer.

I've added tests to match the plaintext tests already created.